### PR TITLE
Fix compilation for newer compilers (C99 or newer)

### DIFF
--- a/CoreSymbolication.h
+++ b/CoreSymbolication.h
@@ -390,7 +390,7 @@ CSSymbolOwnerSetLoadTimestamp
 CSSymbolOwnerSetPath
 CSSymbolOwnerSetRelocationCount
  */
-CSSymbolOwnerSetTransientUserData(CSSymbolOwnerRef owner, uint32_t gen);
+int CSSymbolOwnerSetTransientUserData(CSSymbolOwnerRef owner, uint32_t gen);
  /*
 CSSymbolOwnerSetUnloadTimestamp
 */


### PR DESCRIPTION
```
cc -F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include -fblocks   -c -o CoreSymbolication.o CoreSymbolication.c
In file included from CoreSymbolication.c:1:
./CoreSymbolication.h:393:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
CSSymbolOwnerSetTransientUserData(CSSymbolOwnerRef owner, uint32_t gen);
^
int
1 error generated.
```