### PR TITLE
Add symbols needed to build zlog in system_cmds

### DIFF
--- a/CoreSymbolication.h
+++ b/CoreSymbolication.h
@@ -324,7 +324,9 @@ CSSymbolOwnerEditRelocations
 CSSymbolOwnerForeachRegion
 CSSymbolOwnerForeachRegionWithName
 CSSymbolOwnerForeachSection
-CSSymbolOwnerForeachSegment
+*/
+void CSSymbolOwnerForeachSegment(CSSymbolOwnerRef owner, void (^block)(CSSegmentRef));
+/*
 CSSymbolOwnerForeachSourceInfo
 CSSymbolOwnerForeachSymbol
  */
@@ -333,7 +335,9 @@ void CSSymbolOwnerForeachSymbolWithName(CSSymbolOwnerRef owner,  const char *sna
 /*
 CSSymbolOwnerGetArchitecture
 CSSymbolOwnerGetBaseAddress
-CSSymbolOwnerGetCFUUIDBytes
+*/
+const CFUUIDBytes* CSSymbolOwnerGetCFUUIDBytes(CSSymbolOwnerRef owner);
+/*
 CSSymbolOwnerGetCompatibilityVersion
 CSSymbolOwnerGetCurrentVersion
 CSSymbolOwnerGetDataFlags
@@ -390,7 +394,7 @@ CSSymbolOwnerSetLoadTimestamp
 CSSymbolOwnerSetPath
 CSSymbolOwnerSetRelocationCount
  */
-CSSymbolOwnerSetTransientUserData(CSSymbolOwnerRef owner, uint32_t gen);
+void CSSymbolOwnerSetTransientUserData(CSSymbolOwnerRef owner, uint32_t gen);
  /*
 CSSymbolOwnerSetUnloadTimestamp
 */

--- a/CoreSymbolication.h
+++ b/CoreSymbolication.h
@@ -49,6 +49,7 @@
 
 
 #include <CoreFoundation/CoreFoundation.h>
+#include <CoreFoundation/CFBase.h>
 #include <mach/mach.h>
 
 
@@ -139,13 +140,13 @@ typedef void (^CSSegmentIterator)(CSSegmentRef segment);
  * External symbols
  */
 
-const char* kCSRegionMachHeaderName;
-const CSDictionaryKeyCallBacks kCSTypeDictionaryKeyCallBacks;
-const CSDictionaryValueCallBacks kCSTypeDictionaryValueCallBacks;
-const CSDictionaryKeyCallBacks kCSTypeDictionaryWeakKeyCallBacks;
-const CSDictionaryValueCallBacks kCSTypeDictionaryWeakValueCallBacks;
-const CSSetCallBacks kCSTypeSetCallBacks;
-const CSSetCallBacks kCSTypeSetWeakCallBacks;
+CF_EXPORT const char* kCSRegionMachHeaderName;
+CF_EXPORT const CSDictionaryKeyCallBacks kCSTypeDictionaryKeyCallBacks;
+CF_EXPORT const CSDictionaryValueCallBacks kCSTypeDictionaryValueCallBacks;
+CF_EXPORT const CSDictionaryKeyCallBacks kCSTypeDictionaryWeakKeyCallBacks;
+CF_EXPORT const CSDictionaryValueCallBacks kCSTypeDictionaryWeakValueCallBacks;
+CF_EXPORT const CSSetCallBacks kCSTypeSetCallBacks;
+CF_EXPORT const CSSetCallBacks kCSTypeSetWeakCallBacks;
 
 
 /*


### PR DESCRIPTION
I’m working on an update to system_cmds in nixpkgs, which needs updated symbols from CoreSymbolication.